### PR TITLE
fix: 🐛 Revert of family name min length

### DIFF
--- a/logger/src/options/analyze.py
+++ b/logger/src/options/analyze.py
@@ -46,7 +46,7 @@ last_payload = ""
 current_position = 0
 
 identifier_regex = r"[56][0-9a-f]0100[0-9a-f]{4}"
-name_regex = r"^[A-Z][a-zA-Z0-9_]{1,15}$"
+name_regex = r"^[A-Z][a-zA-Z0-9_]{2,15}$"
 
 
 def package_handler(package, output, ip_filter=True):


### PR DESCRIPTION
This pull request makes a minor adjustment to the regular expression used for validating names in the `extract_string` function. The change ensures that names must now be at least three characters long, rather than two.

* Increased minimum name length in the `name_regex` pattern from 2 to 3 characters in `logger/src/options/analyze.py`, making name validation stricter. Family names auctionned by Pearl Abyss such as I, V, etc. will no longer get picked up
